### PR TITLE
feat: add CraftCommand for 3D model generation using Nano Banana Pro …

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,7 @@
+{
+  "permissions": {
+    "allow": [
+      "Bash(./gradlew build:*)"
+    ]
+  }
+}

--- a/src/client/java/com/falcraft/FalcraftClient.java
+++ b/src/client/java/com/falcraft/FalcraftClient.java
@@ -3,6 +3,7 @@ package com.falcraft;
 import com.falcraft.commands.ConfigCommand;
 import com.falcraft.commands.GenerateCommand;
 import com.falcraft.commands.RemixCommand;
+import com.falcraft.commands.CraftCommand;
 import com.falcraft.commands.StreamCommand;
 import com.falcraft.render.GhostBlockRenderer;
 import com.falcraft.util.PlacementPreview;
@@ -29,6 +30,7 @@ public class FalcraftClient implements ClientModInitializer {
             // RemixCommand.register(dispatcher);  // Coming in v1.1.0
             GenerateCommand.register(dispatcher);
             StreamCommand.register(dispatcher);  // Streaming 3D generation
+            CraftCommand.register(dispatcher);   // Nano Banana Pro + Hunyuan 3D
         });
         
         // Register ghost block renderer for placement preview

--- a/src/client/java/com/falcraft/commands/CraftCommand.java
+++ b/src/client/java/com/falcraft/commands/CraftCommand.java
@@ -1,0 +1,139 @@
+package com.falcraft.commands;
+
+import com.falcraft.util.FalAPI;
+import com.falcraft.util.GLBParser;
+import com.falcraft.util.PlacementPreview;
+import com.falcraft.util.TextureSampler;
+import com.falcraft.util.Voxelizer;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.IntegerArgumentType;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.argument;
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.literal;
+
+import com.mojang.brigadier.suggestion.SuggestionProvider;
+
+/**
+ * Command to generate 3D models using Nano Banana Pro + Hunyuan 3D v3.1 Pro pipeline
+ * Usage: /fal craft <size> <prompt>
+ * Higher quality UV-textured models via Hunyuan 3D
+ */
+public class CraftCommand {
+    private static final Logger LOGGER = LoggerFactory.getLogger("CraftCommand");
+
+    private static final SuggestionProvider<FabricClientCommandSource> SIZE_SUGGESTIONS = (context, builder) -> {
+        builder.suggest(16, Component.literal("Tiny"));
+        builder.suggest(32, Component.literal("Small"));
+        builder.suggest(48, Component.literal("Medium"));
+        builder.suggest(64, Component.literal("Large"));
+        builder.suggest(80, Component.literal("Extra Large"));
+        builder.suggest(96, Component.literal("Huge"));
+        builder.suggest(112, Component.literal("Massive"));
+        builder.suggest(128, Component.literal("Maximum"));
+        return builder.buildFuture();
+    };
+
+    public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher) {
+        dispatcher.register(literal("fal")
+                .then(literal("craft")
+                        .then(argument("size", IntegerArgumentType.integer(16, 128))
+                                .suggests(SIZE_SUGGESTIONS)
+                                .then(argument("prompt", StringArgumentType.greedyString())
+                                        .executes(CraftCommand::execute)))));
+    }
+
+    private static int execute(CommandContext<FabricClientCommandSource> context) {
+        int size = IntegerArgumentType.getInteger(context, "size");
+        String prompt = StringArgumentType.getString(context, "prompt");
+        FabricClientCommandSource source = context.getSource();
+
+        source.sendFeedback(Component.literal("§d[fal] Starting §bCRAFT§d generation (" + size + "x" + size + "x" + size + ")"));
+        source.sendFeedback(Component.literal("§d[fal] Prompt: \"" + prompt + "\""));
+        source.sendFeedback(Component.literal("§d[fal] Using Nano Banana Pro + Hunyuan 3D v3.1 Pro"));
+
+        new Thread(() -> {
+            try {
+                LOGGER.info("Starting Craft pipeline...");
+
+                // Step 1: Generate image with Nano Banana Pro
+                Minecraft.getInstance().execute(() ->
+                    source.sendFeedback(Component.literal("§d[fal] [1/4] Generating image with Nano Banana Pro...")));
+
+                FalAPI falApi = new FalAPI();
+                String imageUrl = falApi.generateImageWithNanoBanana(prompt);
+
+                Minecraft.getInstance().execute(() ->
+                    source.sendFeedback(Component.literal("§d[fal] [2/4] Converting to 3D with Hunyuan 3D...")));
+
+                // Step 2: Convert to 3D with Hunyuan
+                FalAPI.ModelResult modelResult = falApi.generate3DWithHunyuan(imageUrl);
+
+                LOGGER.info("Received GLB model ({} bytes)", modelResult.glbData().length);
+                Minecraft.getInstance().execute(() ->
+                    source.sendFeedback(Component.literal("§d[fal] [3/4] Parsing 3D model...")));
+
+                // Step 3: Extract texture and parse GLB
+                TextureSampler textureSampler = null;
+                try {
+                    byte[] embeddedTexture = GLBParser.extractEmbeddedTexture(modelResult.glbData());
+                    if (embeddedTexture != null) {
+                        textureSampler = new TextureSampler(embeddedTexture);
+                    }
+                } catch (Exception e) {
+                    LOGGER.error("Failed to extract embedded texture: {}", e.getMessage(), e);
+                }
+
+                GLBParser.MeshData meshData = GLBParser.parse(modelResult.glbData(), textureSampler);
+
+                // Step 4: Voxelize
+                final TextureSampler finalTextureSampler = textureSampler;
+                Minecraft.getInstance().execute(() ->
+                    source.sendFeedback(Component.literal("§d[fal] [4/4] Converting to voxels (" +
+                            size + "x" + size + "x" + size + ")...")));
+
+                Voxelizer.VoxelGrid voxelGrid = Voxelizer.voxelize(meshData, size, finalTextureSampler);
+
+                if (voxelGrid.voxels().isEmpty()) {
+                    Minecraft.getInstance().execute(() ->
+                        source.sendError(Component.literal("§c[fal] Error: Generated model has no voxels!")));
+                    return;
+                }
+
+                // Step 5: Enter placement preview
+                Minecraft.getInstance().execute(() -> {
+                    try {
+                        PlacementPreview.startPlacement(voxelGrid);
+
+                        source.sendFeedback(Component.literal(
+                                "§a[fal] \u2713 §bCRAFT§a generation complete! " + voxelGrid.voxels().size() + " blocks ready."));
+                        source.sendFeedback(Component.literal(
+                                "§e[fal] Right-click to place, G to rotate!"));
+                    } catch (Exception e) {
+                        String errorMsg = e.getMessage();
+                        source.sendError(Component.literal("§c[fal] Error preparing placement: " + errorMsg));
+                        LOGGER.error("Error preparing placement", e);
+                    }
+                });
+
+            } catch (IllegalStateException e) {
+                Minecraft.getInstance().execute(() ->
+                    source.sendError(Component.literal("§c[fal] Error: API key not configured. Use /fal setkey <key>")));
+                LOGGER.error("API key not configured", e);
+            } catch (Exception e) {
+                String errorMsg = e.getMessage();
+                Minecraft.getInstance().execute(() ->
+                    source.sendError(Component.literal("§c[fal] Error during craft generation: " + errorMsg)));
+                LOGGER.error("Error during Craft 3D generation process", e);
+            }
+        }, "fal-Craft-Thread").start();
+
+        return 1;
+    }
+}

--- a/src/client/java/com/falcraft/util/FalAPI.java
+++ b/src/client/java/com/falcraft/util/FalAPI.java
@@ -25,6 +25,8 @@ public class FalAPI {
     private static final String FAL_ZIMAGE_QUEUE_SUBMIT = "https://queue.fal.run/fal-ai/z-image/turbo";
     private static final String FAL_SAM3_QUEUE_SUBMIT = "https://queue.fal.run/fal-ai/sam-3/3d-objects";
     private static final String FAL_VLM_QUEUE_SUBMIT = "https://queue.fal.run/openrouter/router/vision";
+    private static final String FAL_NANOBANANA_QUEUE_SUBMIT = "https://queue.fal.run/fal-ai/nano-banana-pro";
+    private static final String FAL_HUNYUAN_QUEUE_SUBMIT = "https://queue.fal.run/fal-ai/hunyuan-3d/v3.1/pro/image-to-3d";
     private static final Gson GSON = new Gson();
     private final HttpClient httpClient;
     private final String apiKey;
@@ -653,6 +655,202 @@ public class FalAPI {
         }
         
         return result;
+    }
+
+    // ==================== CRAFT MODE: Nano Banana Pro + Hunyuan 3D Pipeline ====================
+
+    /**
+     * Generates an image from a text prompt using Nano Banana Pro (Gemini 3 Pro Image)
+     * Optimized for 3D conversion with white background and diagonal view
+     * @param prompt The base prompt (will be augmented for 3D-friendly output)
+     * @return The URL of the generated image
+     */
+    public String generateImageWithNanoBanana(String prompt) throws IOException, InterruptedException {
+        String augmentedPrompt = prompt + " image with plain white background, view from diagonally above";
+
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("prompt", augmentedPrompt);
+        requestBody.addProperty("num_images", 1);
+        requestBody.addProperty("aspect_ratio", "1:1");
+        requestBody.addProperty("output_format", "png");
+        requestBody.addProperty("resolution", "1K");
+
+        String requestBodyJson = GSON.toJson(requestBody);
+
+        HttpRequest submitRequest = HttpRequest.newBuilder()
+                .uri(URI.create(FAL_NANOBANANA_QUEUE_SUBMIT))
+                .header("Authorization", "Key " + apiKey)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBodyJson))
+                .build();
+
+        HttpResponse<String> submitResponse = httpClient.send(submitRequest, HttpResponse.BodyHandlers.ofString());
+
+        if (submitResponse.statusCode() != 200) {
+            LOGGER.error("Nano Banana Pro queue submit error: {} - {}", submitResponse.statusCode(), submitResponse.body());
+            throw new IOException("Failed to submit Nano Banana Pro request: " + submitResponse.statusCode());
+        }
+
+        JsonObject submitJson = GSON.fromJson(submitResponse.body(), JsonObject.class);
+        String responseUrl = submitJson.get("response_url").getAsString();
+        String statusUrl = submitJson.get("status_url").getAsString();
+
+        // Poll for completion
+        boolean completed = false;
+        int attempts = 0;
+        int maxAttempts = 60; // 60 attempts * 2 seconds = 2 minutes max
+
+        while (!completed && attempts < maxAttempts) {
+            Thread.sleep(2000);
+            attempts++;
+
+            HttpRequest statusRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(statusUrl))
+                    .header("Authorization", "Key " + apiKey)
+                    .GET()
+                    .build();
+
+            HttpResponse<String> statusResponse = httpClient.send(statusRequest, HttpResponse.BodyHandlers.ofString());
+
+            if (statusResponse.statusCode() == 200 || statusResponse.statusCode() == 202) {
+                JsonObject statusJson = GSON.fromJson(statusResponse.body(), JsonObject.class);
+                String status = statusJson.get("status").getAsString();
+
+                if ("COMPLETED".equals(status)) {
+                    completed = true;
+                } else if ("FAILED".equals(status)) {
+                    throw new IOException("Nano Banana Pro generation failed");
+                }
+            }
+        }
+
+        if (!completed) {
+            throw new IOException("Nano Banana Pro generation timed out after " + maxAttempts + " attempts");
+        }
+
+        HttpRequest resultRequest = HttpRequest.newBuilder()
+                .uri(URI.create(responseUrl))
+                .header("Authorization", "Key " + apiKey)
+                .GET()
+                .build();
+
+        HttpResponse<String> resultResponse = httpClient.send(resultRequest, HttpResponse.BodyHandlers.ofString());
+
+        if (resultResponse.statusCode() != 200) {
+            LOGGER.error("Failed to get Nano Banana Pro result: {} - {}", resultResponse.statusCode(), resultResponse.body());
+            throw new IOException("Failed to get Nano Banana Pro result from fal");
+        }
+
+        JsonObject resultJson = GSON.fromJson(resultResponse.body(), JsonObject.class);
+        String imageUrl = resultJson.getAsJsonArray("images")
+                .get(0).getAsJsonObject()
+                .get("url").getAsString();
+
+        LOGGER.info("Nano Banana Pro image generated: {}", imageUrl);
+        return imageUrl;
+    }
+
+    /**
+     * Converts an image to a 3D model using Hunyuan 3D v3.1 Pro
+     * Produces high-quality UV-textured GLB models
+     * @param imageUrl The URL of the front-view source image
+     * @return ModelResult containing the GLB data
+     */
+    public ModelResult generate3DWithHunyuan(String imageUrl) throws IOException, InterruptedException {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("input_image_url", imageUrl);
+        requestBody.addProperty("generate_type", "Normal");
+        requestBody.addProperty("enable_pbr", false);
+
+        String requestBodyJson = GSON.toJson(requestBody);
+
+        HttpRequest submitRequest = HttpRequest.newBuilder()
+                .uri(URI.create(FAL_HUNYUAN_QUEUE_SUBMIT))
+                .header("Authorization", "Key " + apiKey)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(requestBodyJson))
+                .build();
+
+        HttpResponse<String> submitResponse = httpClient.send(submitRequest, HttpResponse.BodyHandlers.ofString());
+
+        if (submitResponse.statusCode() != 200) {
+            LOGGER.error("Hunyuan 3D queue submit error: {} - {}", submitResponse.statusCode(), submitResponse.body());
+            throw new IOException("Failed to submit Hunyuan 3D request: " + submitResponse.statusCode());
+        }
+
+        JsonObject submitJson = GSON.fromJson(submitResponse.body(), JsonObject.class);
+        String responseUrl = submitJson.get("response_url").getAsString();
+        String statusUrl = submitJson.get("status_url").getAsString();
+
+        // Poll for completion (Hunyuan 3D can take a few minutes)
+        boolean completed = false;
+        int attempts = 0;
+        int maxAttempts = 120; // 120 attempts * 3 seconds = 6 minutes max
+
+        while (!completed && attempts < maxAttempts) {
+            Thread.sleep(3000);
+            attempts++;
+
+            HttpRequest statusRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(statusUrl))
+                    .header("Authorization", "Key " + apiKey)
+                    .GET()
+                    .build();
+
+            HttpResponse<String> statusResponse = httpClient.send(statusRequest, HttpResponse.BodyHandlers.ofString());
+
+            if (statusResponse.statusCode() == 200 || statusResponse.statusCode() == 202) {
+                JsonObject statusJson = GSON.fromJson(statusResponse.body(), JsonObject.class);
+                String status = statusJson.get("status").getAsString();
+
+                if ("COMPLETED".equals(status)) {
+                    completed = true;
+                } else if ("FAILED".equals(status)) {
+                    throw new IOException("Hunyuan 3D generation failed");
+                }
+            }
+        }
+
+        if (!completed) {
+            throw new IOException("Hunyuan 3D generation timed out after " + maxAttempts + " attempts");
+        }
+
+        HttpRequest resultRequest = HttpRequest.newBuilder()
+                .uri(URI.create(responseUrl))
+                .header("Authorization", "Key " + apiKey)
+                .GET()
+                .build();
+
+        HttpResponse<String> resultResponse = httpClient.send(resultRequest, HttpResponse.BodyHandlers.ofString());
+
+        if (resultResponse.statusCode() != 200) {
+            LOGGER.error("Failed to get Hunyuan 3D result: {} - {}", resultResponse.statusCode(), resultResponse.body());
+            throw new IOException("Failed to get Hunyuan 3D result from fal: " + resultResponse.statusCode());
+        }
+
+        JsonObject resultJson = GSON.fromJson(resultResponse.body(), JsonObject.class);
+        String glbUrl = resultJson.getAsJsonObject("model_glb")
+                .get("url").getAsString();
+
+        LOGGER.info("Hunyuan 3D model generated, downloading GLB...");
+        byte[] glbData = downloadFile(glbUrl);
+
+        // Hunyuan produces UV-textured GLB with embedded textures
+        return new ModelResult(glbData, null);
+    }
+
+    /**
+     * Full Craft pipeline: Nano Banana Pro (text→image) + Hunyuan 3D v3.1 Pro (image→3D)
+     * Higher quality than Z-Image + SAM-3D, takes a bit longer
+     * @param prompt The text prompt describing the desired 3D model
+     * @return ModelResult containing GLB data
+     */
+    public ModelResult generateModelHunyuan(String prompt) throws IOException, InterruptedException {
+        // Step 1: Generate 2D image with Nano Banana Pro
+        String imageUrl = generateImageWithNanoBanana(prompt);
+
+        // Step 2: Convert image to 3D with Hunyuan 3D v3.1 Pro
+        return generate3DWithHunyuan(imageUrl);
     }
 }
 


### PR DESCRIPTION
…and Hunyuan 3D

- Introduced CraftCommand to facilitate the generation of 3D models from text prompts.
- Integrated new methods in FalAPI for image generation and 3D conversion.
- Updated FalcraftClient to register the CraftCommand.
- Added settings for command permissions in settings.local.json.