### PR TITLE
feat: /fal image - AI images as full-fidelity in-world canvases

### DIFF
--- a/src/client/java/com/falcraft/FalcraftClient.java
+++ b/src/client/java/com/falcraft/FalcraftClient.java
@@ -5,15 +5,20 @@ import com.falcraft.commands.GenerateCommand;
 import com.falcraft.commands.RemixCommand;
 import com.falcraft.commands.CraftCommand;
 import com.falcraft.commands.SplatCommand;
+import com.falcraft.commands.ImageCommand;
 import com.falcraft.commands.StreamCommand;
 import com.falcraft.render.GhostBlockRenderer;
+import com.falcraft.render.ImageCanvasRenderer;
+import com.falcraft.util.ImageCanvasManager;
 import com.falcraft.util.PlacementPreview;
 import net.fabricmc.api.ClientModInitializer;
 import net.fabricmc.fabric.api.client.command.v2.ClientCommandRegistrationCallback;
 import net.fabricmc.fabric.api.client.event.lifecycle.v1.ClientTickEvents;
 import net.fabricmc.fabric.api.client.rendering.v1.WorldRenderEvents;
+import net.fabricmc.fabric.api.event.player.AttackBlockCallback;
 import net.minecraft.client.Minecraft;
 import net.minecraft.network.chat.Component;
+import net.minecraft.world.InteractionResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -27,6 +32,13 @@ public class FalcraftClient implements ClientModInitializer {
     private static boolean wasMoveUpKeyPressed = false;
     private static boolean wasMoveDownKeyPressed = false;
 
+    // Image-canvas placement key edges
+    private static boolean imgWasRightClickPressed = false;
+    private static boolean imgWasRotatePressed = false;
+    private static boolean imgWasGrowPressed = false;
+    private static boolean imgWasShrinkPressed = false;
+    private static boolean imgWasSnapPressed = false;
+
     @Override
     public void onInitializeClient() {
         // Register the client-side commands
@@ -37,8 +49,9 @@ public class FalcraftClient implements ClientModInitializer {
             StreamCommand.register(dispatcher);  // Streaming 3D generation
             CraftCommand.register(dispatcher);   // Nano Banana Pro + Hunyuan 3D
             SplatCommand.register(dispatcher);   // Nano Banana Pro + TripoSplat (experimental)
+            ImageCommand.register(dispatcher);   // AI image -> in-world canvas
         });
-        
+
         // Register ghost block renderer for placement preview
         WorldRenderEvents.AFTER_TRANSLUCENT.register(context -> {
             GhostBlockRenderer.render(
@@ -46,13 +59,36 @@ public class FalcraftClient implements ClientModInitializer {
                 context.consumers(),
                 context.tickCounter().getGameTimeDeltaPartialTick(true)
             );
+            // Render placed image canvases + live placement preview
+            ImageCanvasRenderer.render(
+                context.matrixStack(),
+                context.camera().getPosition()
+            );
+        });
+
+        // Left-click an image canvas to remove it (cancels the block-break behind it)
+        AttackBlockCallback.EVENT.register((player, world, hand, pos, direction) -> {
+            if (world.isClientSide && !ImageCanvasManager.isPreviewActive()
+                    && ImageCanvasManager.removeLookedAt(player)) {
+                return InteractionResult.FAIL; // consume the click, don't break the wall
+            }
+            return InteractionResult.PASS;
         });
         
         // Register client tick handler for placement confirmation and animated placement
         // This detects right-clicks anywhere, not just when targeting blocks
         ClientTickEvents.END_CLIENT_TICK.register(client -> {
+            // Load/unload persisted image canvases as the world changes (runs even with no player)
+            ImageCanvasManager.tickLoad(client);
+
             if (client.player == null) return;
-            
+
+            // Image-canvas placement preview takes over input while active
+            if (ImageCanvasManager.isPreviewActive()) {
+                handleImagePlacementKeys(client);
+                return;
+            }
+
             // Tick animated placement if active
             if (PlacementPreview.isAnimatingPlacement()) {
                 PlacementPreview.tickAnimatedPlacement();
@@ -178,6 +214,65 @@ public class FalcraftClient implements ClientModInitializer {
         });
         
         LOGGER.info("Falcraft client initialized");
+    }
+
+    /**
+     * Handles input while an image-canvas placement preview is active:
+     * right-click to place, G to rotate facing, H/N to grow/shrink.
+     */
+    private static void handleImagePlacementKeys(Minecraft client) {
+        long window = client.getWindow().getWindow();
+
+        // Right-click (use key) places the canvas at the current target
+        boolean rightClick = client.options.keyUse.isDown();
+        if (rightClick && !imgWasRightClickPressed) {
+            ImageCanvasManager.confirmPlacement();
+            if (client.player != null) {
+                client.player.displayClientMessage(Component.literal("§a[fal] 🖼 Image placed!"), true);
+            }
+        }
+        imgWasRightClickPressed = rightClick;
+
+        // G: rotate facing
+        boolean rotate = org.lwjgl.glfw.GLFW.glfwGetKey(window, org.lwjgl.glfw.GLFW.GLFW_KEY_G) == org.lwjgl.glfw.GLFW.GLFW_PRESS;
+        if (rotate && !imgWasRotatePressed) {
+            ImageCanvasManager.rotateFacing();
+            if (client.player != null) {
+                client.player.displayClientMessage(Component.literal("§e[fal] Rotated facing"), true);
+            }
+        }
+        imgWasRotatePressed = rotate;
+
+        // H: grow
+        boolean grow = org.lwjgl.glfw.GLFW.glfwGetKey(window, org.lwjgl.glfw.GLFW.GLFW_KEY_H) == org.lwjgl.glfw.GLFW.GLFW_PRESS;
+        if (grow && !imgWasGrowPressed) {
+            ImageCanvasManager.grow();
+            if (client.player != null) {
+                client.player.displayClientMessage(Component.literal("§e[fal] Size: " + ImageCanvasManager.getWidthBlocks() + " wide"), true);
+            }
+        }
+        imgWasGrowPressed = grow;
+
+        // N: shrink
+        boolean shrink = org.lwjgl.glfw.GLFW.glfwGetKey(window, org.lwjgl.glfw.GLFW.GLFW_KEY_N) == org.lwjgl.glfw.GLFW.GLFW_PRESS;
+        if (shrink && !imgWasShrinkPressed) {
+            ImageCanvasManager.shrink();
+            if (client.player != null) {
+                client.player.displayClientMessage(Component.literal("§e[fal] Size: " + ImageCanvasManager.getWidthBlocks() + " wide"), true);
+            }
+        }
+        imgWasShrinkPressed = shrink;
+
+        // F: toggle snap-to-block vs free-hand
+        boolean snap = org.lwjgl.glfw.GLFW.glfwGetKey(window, org.lwjgl.glfw.GLFW.GLFW_KEY_F) == org.lwjgl.glfw.GLFW.GLFW_PRESS;
+        if (snap && !imgWasSnapPressed) {
+            ImageCanvasManager.toggleSnap();
+            if (client.player != null) {
+                client.player.displayClientMessage(Component.literal(
+                        "§e[fal] Snap: " + (ImageCanvasManager.isSnapEnabled() ? "ON (block-aligned)" : "OFF (free-hand)")), true);
+            }
+        }
+        imgWasSnapPressed = snap;
     }
 }
 

--- a/src/client/java/com/falcraft/commands/ImageCommand.java
+++ b/src/client/java/com/falcraft/commands/ImageCommand.java
@@ -1,0 +1,108 @@
+package com.falcraft.commands;
+
+import com.falcraft.util.FalAPI;
+import com.falcraft.util.ImageCanvasManager;
+import com.mojang.brigadier.CommandDispatcher;
+import com.mojang.brigadier.arguments.StringArgumentType;
+import com.mojang.brigadier.context.CommandContext;
+import net.fabricmc.fabric.api.client.command.v2.FabricClientCommandSource;
+import net.minecraft.client.Minecraft;
+import net.minecraft.network.chat.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.argument;
+import static net.fabricmc.fabric.api.client.command.v2.ClientCommandManager.literal;
+
+/**
+ * Generates an AI image and hangs it in the world as a full-fidelity textured canvas.
+ * Usage:
+ *   /fal image <prompt>        - high fidelity (Nano Banana Pro)
+ *   /fal image fast <prompt>   - quick/cheap (Z-Image Turbo)
+ *   /fal image cancel          - cancel the current placement preview
+ *
+ * After generation a live preview follows your crosshair: look at a wall, then
+ * right-click to place. G = rotate facing, H/N = bigger/smaller.
+ */
+public class ImageCommand {
+    private static final Logger LOGGER = LoggerFactory.getLogger("ImageCommand");
+
+    public static void register(CommandDispatcher<FabricClientCommandSource> dispatcher) {
+        dispatcher.register(literal("fal")
+                .then(literal("image")
+                        // /fal image <prompt> -> Nano Banana Pro
+                        .then(argument("prompt", StringArgumentType.greedyString())
+                                .executes(ctx -> execute(ctx, false)))
+                        // /fal image fast <prompt> -> Z-Image Turbo
+                        .then(literal("fast")
+                                .then(argument("prompt", StringArgumentType.greedyString())
+                                        .executes(ctx -> execute(ctx, true))))
+                        // /fal image cancel
+                        .then(literal("cancel")
+                                .executes(ImageCommand::executeCancel))
+                        // /fal image clear
+                        .then(literal("clear")
+                                .executes(ImageCommand::executeClear))));
+    }
+
+    private static int executeClear(CommandContext<FabricClientCommandSource> context) {
+        FabricClientCommandSource source = context.getSource();
+        Minecraft.getInstance().execute(() -> {
+            int n = ImageCanvasManager.clearCurrentDimension();
+            source.sendFeedback(Component.literal("§e[fal] Removed " + n + " image canvas(es)."));
+        });
+        return 1;
+    }
+
+    private static int executeCancel(CommandContext<FabricClientCommandSource> context) {
+        FabricClientCommandSource source = context.getSource();
+        if (ImageCanvasManager.isPreviewActive()) {
+            Minecraft.getInstance().execute(ImageCanvasManager::cancelPreview);
+            source.sendFeedback(Component.literal("§e[fal] Image placement cancelled."));
+        } else {
+            source.sendFeedback(Component.literal("§7[fal] No image preview to cancel."));
+        }
+        return 1;
+    }
+
+    private static int execute(CommandContext<FabricClientCommandSource> context, boolean fast) {
+        String prompt = StringArgumentType.getString(context, "prompt");
+        FabricClientCommandSource source = context.getSource();
+        String model = fast ? "Z-Image Turbo" : "Nano Banana Pro";
+
+        source.sendFeedback(Component.literal("§d[fal] Generating image with §b" + model + "§d..."));
+        source.sendFeedback(Component.literal("§d[fal] Prompt: \"" + prompt + "\""));
+
+        new Thread(() -> {
+            try {
+                FalAPI falApi = new FalAPI();
+                String imageUrl = fast
+                        ? falApi.generatePictureZImage(prompt)
+                        : falApi.generatePictureNanoBanana(prompt);
+
+                byte[] png = falApi.downloadFile(imageUrl);
+                LOGGER.info("Downloaded picture ({} bytes)", png.length);
+
+                Minecraft.getInstance().execute(() -> {
+                    ImageCanvasManager.startPreview(png);
+                    source.sendFeedback(Component.literal(
+                            "§a[fal] ✓ Image ready! Look at a wall and right-click to place."));
+                    source.sendFeedback(Component.literal(
+                            "§e[fal] G = rotate, H/N = bigger/smaller, /fal image cancel to abort."));
+                });
+
+            } catch (IllegalStateException e) {
+                Minecraft.getInstance().execute(() ->
+                        source.sendError(Component.literal("§c[fal] Error: API key not configured. Use /fal setkey <key>")));
+                LOGGER.error("API key not configured", e);
+            } catch (Exception e) {
+                String msg = e.getMessage();
+                Minecraft.getInstance().execute(() ->
+                        source.sendError(Component.literal("§c[fal] Error during image generation: " + msg)));
+                LOGGER.error("Error during image generation", e);
+            }
+        }, "fal-Image-Thread").start();
+
+        return 1;
+    }
+}

--- a/src/client/java/com/falcraft/render/ImageCanvasRenderer.java
+++ b/src/client/java/com/falcraft/render/ImageCanvasRenderer.java
@@ -1,0 +1,115 @@
+package com.falcraft.render;
+
+import com.falcraft.util.ImageCanvasManager;
+import com.falcraft.util.ImageCanvasManager.CanvasTransform;
+import com.mojang.blaze3d.systems.RenderSystem;
+import com.mojang.blaze3d.vertex.BufferBuilder;
+import com.mojang.blaze3d.vertex.BufferUploader;
+import com.mojang.blaze3d.vertex.DefaultVertexFormat;
+import com.mojang.blaze3d.vertex.PoseStack;
+import com.mojang.blaze3d.vertex.Tesselator;
+import com.mojang.blaze3d.vertex.VertexFormat;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.renderer.GameRenderer;
+import net.minecraft.core.Direction;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.phys.Vec3;
+import org.joml.Matrix4f;
+
+/**
+ * Renders AI-generated image canvases in the world as full-fidelity textured quads,
+ * plus a live placement preview that follows the player's crosshair.
+ */
+public class ImageCanvasRenderer {
+
+    private static final Vec3 UP = new Vec3(0, 1, 0);
+    private static final double BORDER_MARGIN = 0.12; // world units of frame around the image
+
+    public static void render(PoseStack poseStack, Vec3 cameraPos) {
+        var placed = ImageCanvasManager.getPlacedCanvases();
+        boolean preview = ImageCanvasManager.isPreviewActive();
+        if (placed.isEmpty() && !preview) {
+            return;
+        }
+
+        RenderSystem.enableBlend();
+        RenderSystem.defaultBlendFunc();
+        RenderSystem.enableDepthTest();
+        RenderSystem.depthMask(true);
+        RenderSystem.disableCull();
+
+        // Placed canvases: full opacity, dark frame.
+        for (ImageCanvasManager.ImageCanvas c : placed) {
+            drawCanvas(poseStack, cameraPos, c.toTransform(), c.texture, 1.0f,
+                    0.08f, 0.08f, 0.08f, 1.0f);
+        }
+
+        // Live preview: slightly transparent, bright yellow frame.
+        if (preview) {
+            LocalPlayer player = Minecraft.getInstance().player;
+            ResourceLocation tex = ImageCanvasManager.getPreviewTexture();
+            if (player != null && tex != null) {
+                CanvasTransform t = ImageCanvasManager.computeTargetTransform(player);
+                drawCanvas(poseStack, cameraPos, t, tex, 0.85f,
+                        1.0f, 0.85f, 0.2f, 0.9f);
+            }
+        }
+
+        RenderSystem.enableCull();
+        RenderSystem.setShaderColor(1, 1, 1, 1);
+        RenderSystem.disableBlend();
+    }
+
+    private static void drawCanvas(PoseStack poseStack, Vec3 cameraPos, CanvasTransform t,
+            ResourceLocation texture, float alpha,
+            float br, float bg, float bb, float ba) {
+        Direction facing = t.facing();
+        Vec3 normal = Vec3.atLowerCornerOf(facing.getNormal());
+        Vec3 right = UP.cross(normal).normalize();
+        double hw = t.width() / 2.0;
+        double hh = t.height() / 2.0;
+
+        // Center relative to camera.
+        Vec3 c = t.center().subtract(cameraPos);
+
+        Vec3 rW = right.scale(hw);
+        Vec3 uH = UP.scale(hh);
+
+        Matrix4f matrix = poseStack.last().pose();
+
+        // ---- Frame (drawn first, slightly behind and larger) ----
+        Vec3 cBack = c.subtract(normal.scale(0.005));
+        Vec3 rWb = right.scale(hw + BORDER_MARGIN);
+        Vec3 uHb = UP.scale(hh + BORDER_MARGIN);
+        Vec3 fbl = cBack.subtract(rWb).subtract(uHb);
+        Vec3 fbr = cBack.add(rWb).subtract(uHb);
+        Vec3 ftr = cBack.add(rWb).add(uHb);
+        Vec3 ftl = cBack.subtract(rWb).add(uHb);
+
+        RenderSystem.setShader(GameRenderer::getPositionColorShader);
+        BufferBuilder frame = Tesselator.getInstance().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_COLOR);
+        frame.addVertex(matrix, (float) fbl.x, (float) fbl.y, (float) fbl.z).setColor(br, bg, bb, ba);
+        frame.addVertex(matrix, (float) fbr.x, (float) fbr.y, (float) fbr.z).setColor(br, bg, bb, ba);
+        frame.addVertex(matrix, (float) ftr.x, (float) ftr.y, (float) ftr.z).setColor(br, bg, bb, ba);
+        frame.addVertex(matrix, (float) ftl.x, (float) ftl.y, (float) ftl.z).setColor(br, bg, bb, ba);
+        BufferUploader.drawWithShader(frame.buildOrThrow());
+
+        // ---- Image quad ----
+        Vec3 bl = c.subtract(rW).subtract(uH);
+        Vec3 brc = c.add(rW).subtract(uH);
+        Vec3 tr = c.add(rW).add(uH);
+        Vec3 tl = c.subtract(rW).add(uH);
+
+        RenderSystem.setShader(GameRenderer::getPositionTexShader);
+        RenderSystem.setShaderTexture(0, texture);
+        RenderSystem.setShaderColor(1, 1, 1, alpha);
+        BufferBuilder img = Tesselator.getInstance().begin(VertexFormat.Mode.QUADS, DefaultVertexFormat.POSITION_TEX);
+        img.addVertex(matrix, (float) bl.x, (float) bl.y, (float) bl.z).setUv(0f, 1f);
+        img.addVertex(matrix, (float) brc.x, (float) brc.y, (float) brc.z).setUv(1f, 1f);
+        img.addVertex(matrix, (float) tr.x, (float) tr.y, (float) tr.z).setUv(1f, 0f);
+        img.addVertex(matrix, (float) tl.x, (float) tl.y, (float) tl.z).setUv(0f, 0f);
+        BufferUploader.drawWithShader(img.buildOrThrow());
+        RenderSystem.setShaderColor(1, 1, 1, 1);
+    }
+}

--- a/src/client/java/com/falcraft/util/FalAPI.java
+++ b/src/client/java/com/falcraft/util/FalAPI.java
@@ -1063,5 +1063,109 @@ public class FalAPI {
         // Step 2: Convert image to a Gaussian splat with TripoSplat
         return generateSplatWithTripoSplat(imageUrl, numGaussians);
     }
+
+    // ==================== IMAGE MODE: standalone picture generation ====================
+    // Unlike the 3D image helpers, these do NOT augment the prompt for segmentation
+    // (no "white background, single subject" suffix) - we want the picture as prompted.
+
+    /**
+     * Generates a high-fidelity picture from a text prompt using Nano Banana Pro.
+     * @param prompt The text prompt (used as-is)
+     * @return The URL of the generated image
+     */
+    public String generatePictureNanoBanana(String prompt) throws IOException, InterruptedException {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("prompt", prompt);
+        requestBody.addProperty("num_images", 1);
+        requestBody.addProperty("aspect_ratio", "1:1");
+        requestBody.addProperty("output_format", "png");
+        requestBody.addProperty("resolution", "1K");
+        return pollImageResult(FAL_NANOBANANA_QUEUE_SUBMIT, requestBody, 60, 2000, "Nano Banana Pro");
+    }
+
+    /**
+     * Generates a quick, cheap picture from a text prompt using Z-Image Turbo.
+     * @param prompt The text prompt (used as-is)
+     * @return The URL of the generated image
+     */
+    public String generatePictureZImage(String prompt) throws IOException, InterruptedException {
+        JsonObject requestBody = new JsonObject();
+        requestBody.addProperty("prompt", prompt);
+        requestBody.addProperty("image_size", "square_hd");
+        requestBody.addProperty("num_inference_steps", 8);
+        requestBody.addProperty("num_images", 1);
+        requestBody.addProperty("enable_safety_checker", true);
+        requestBody.addProperty("output_format", "png");
+        return pollImageResult(FAL_ZIMAGE_QUEUE_SUBMIT, requestBody, 30, 1000, "Z-Image Turbo");
+    }
+
+    /**
+     * Submits an image-generation request to a fal queue endpoint, polls until done,
+     * and returns the first image URL. Shared by the picture generators above.
+     */
+    private String pollImageResult(String endpoint, JsonObject requestBody, int maxAttempts,
+            long pollMillis, String label) throws IOException, InterruptedException {
+        HttpRequest submitRequest = HttpRequest.newBuilder()
+                .uri(URI.create(endpoint))
+                .header("Authorization", "Key " + apiKey)
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(GSON.toJson(requestBody)))
+                .build();
+
+        HttpResponse<String> submitResponse = httpClient.send(submitRequest, HttpResponse.BodyHandlers.ofString());
+        if (submitResponse.statusCode() != 200) {
+            LOGGER.error("{} queue submit error: {} - {}", label, submitResponse.statusCode(), submitResponse.body());
+            throw new IOException("Failed to submit " + label + " request: " + submitResponse.statusCode());
+        }
+
+        JsonObject submitJson = GSON.fromJson(submitResponse.body(), JsonObject.class);
+        String responseUrl = submitJson.get("response_url").getAsString();
+        String statusUrl = submitJson.get("status_url").getAsString();
+
+        boolean completed = false;
+        int attempts = 0;
+        while (!completed && attempts < maxAttempts) {
+            Thread.sleep(pollMillis);
+            attempts++;
+
+            HttpRequest statusRequest = HttpRequest.newBuilder()
+                    .uri(URI.create(statusUrl))
+                    .header("Authorization", "Key " + apiKey)
+                    .GET()
+                    .build();
+            HttpResponse<String> statusResponse = httpClient.send(statusRequest, HttpResponse.BodyHandlers.ofString());
+
+            if (statusResponse.statusCode() == 200 || statusResponse.statusCode() == 202) {
+                JsonObject statusJson = GSON.fromJson(statusResponse.body(), JsonObject.class);
+                String status = statusJson.get("status").getAsString();
+                if ("COMPLETED".equals(status)) {
+                    completed = true;
+                } else if ("FAILED".equals(status)) {
+                    throw new IOException(label + " generation failed");
+                }
+            }
+        }
+        if (!completed) {
+            throw new IOException(label + " generation timed out after " + maxAttempts + " attempts");
+        }
+
+        HttpRequest resultRequest = HttpRequest.newBuilder()
+                .uri(URI.create(responseUrl))
+                .header("Authorization", "Key " + apiKey)
+                .GET()
+                .build();
+        HttpResponse<String> resultResponse = httpClient.send(resultRequest, HttpResponse.BodyHandlers.ofString());
+        if (resultResponse.statusCode() != 200) {
+            LOGGER.error("Failed to get {} result: {} - {}", label, resultResponse.statusCode(), resultResponse.body());
+            throw new IOException("Failed to get " + label + " result from fal");
+        }
+
+        JsonObject resultJson = GSON.fromJson(resultResponse.body(), JsonObject.class);
+        String imageUrl = resultJson.getAsJsonArray("images")
+                .get(0).getAsJsonObject()
+                .get("url").getAsString();
+        LOGGER.info("{} picture generated: {}", label, imageUrl);
+        return imageUrl;
+    }
 }
 

--- a/src/client/java/com/falcraft/util/ImageCanvasManager.java
+++ b/src/client/java/com/falcraft/util/ImageCanvasManager.java
@@ -1,0 +1,432 @@
+package com.falcraft.util;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+import com.mojang.blaze3d.platform.NativeImage;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.player.LocalPlayer;
+import net.minecraft.client.renderer.texture.DynamicTexture;
+import net.minecraft.core.Direction;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.level.ClipContext;
+import net.minecraft.world.phys.BlockHitResult;
+import net.minecraft.world.phys.HitResult;
+import net.minecraft.world.phys.Vec3;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.ByteArrayInputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Manages AI-generated image "canvases" displayed in the world as full-fidelity
+ * textured quads (Route B). Handles:
+ * - a live placement preview that follows the player's crosshair onto walls,
+ * - registering the downloaded PNG as a DynamicTexture,
+ * - persisting placed canvases to disk and reloading them per world/dimension.
+ *
+ * All client-side; like falcraft's block placement, persistence is single-player oriented.
+ */
+public class ImageCanvasManager {
+    private static final Logger LOGGER = LoggerFactory.getLogger("ImageCanvasManager");
+    private static final Gson GSON = new GsonBuilder().setPrettyPrinting().create();
+
+    private static final Direction[] HORIZONTALS = {
+            Direction.NORTH, Direction.EAST, Direction.SOUTH, Direction.WEST
+    };
+    private static final int DEFAULT_WIDTH_BLOCKS = 4;
+    private static final int MIN_WIDTH_BLOCKS = 1;
+    private static final int MAX_WIDTH_BLOCKS = 32;
+    private static final double WALL_OFFSET = 0.02; // push quad off the wall to avoid z-fighting
+
+    /** A placement: where a canvas sits and how big it is. */
+    public record CanvasTransform(Vec3 center, Direction facing, double width, double height) {}
+
+    /** A placed (or persisted) image canvas. */
+    public static final class ImageCanvas {
+        public final String id;
+        public final String dim;
+        public final Vec3 center;
+        public final Direction facing;
+        public final double width;
+        public final double height;
+        public final ResourceLocation texture;
+
+        ImageCanvas(String id, String dim, Vec3 center, Direction facing,
+                    double width, double height, ResourceLocation texture) {
+            this.id = id;
+            this.dim = dim;
+            this.center = center;
+            this.facing = facing;
+            this.width = width;
+            this.height = height;
+            this.texture = texture;
+        }
+
+        public CanvasTransform toTransform() {
+            return new CanvasTransform(center, facing, width, height);
+        }
+    }
+
+    /** Gson DTO for the on-disk manifest (no ResourceLocation/Vec3). */
+    private static final class CanvasRecord {
+        String id, dim, facing;
+        double x, y, z, width, height;
+    }
+
+    private static final List<ImageCanvas> placed = new ArrayList<>();
+
+    // Preview state
+    private static boolean previewActive = false;
+    private static byte[] pendingBytes = null;
+    private static String pendingId = null;
+    private static ResourceLocation pendingTexture = null;
+    private static double aspect = 1.0; // height / width of the source image
+    private static int widthBlocks = DEFAULT_WIDTH_BLOCKS;
+    private static int forcedFacingIndex = -1; // -1 = auto from wall/look
+    private static boolean snapEnabled = true; // snap center to the targeted block's face
+
+    // Persistence load guard
+    private static String loadedDim = null;
+
+    // ==================== PREVIEW ====================
+
+    /**
+     * Starts the placement preview for a freshly generated image.
+     * @param pngBytes the downloaded PNG
+     */
+    public static void startPreview(byte[] pngBytes) {
+        try {
+            NativeImage img = NativeImage.read(new ByteArrayInputStream(pngBytes));
+            int w = img.getWidth();
+            int h = img.getHeight();
+
+            String id = String.valueOf(System.currentTimeMillis());
+            ResourceLocation loc = ResourceLocation.fromNamespaceAndPath("falcraft", "canvas/" + id);
+            Minecraft.getInstance().getTextureManager().register(loc, new DynamicTexture(img));
+
+            pendingBytes = pngBytes;
+            pendingId = id;
+            pendingTexture = loc;
+            aspect = h > 0 ? (double) h / w : 1.0;
+            widthBlocks = DEFAULT_WIDTH_BLOCKS;
+            forcedFacingIndex = -1;
+            previewActive = true;
+
+            LOGGER.info("Image preview started ({}x{}, aspect {}) texture {}", w, h, aspect, loc);
+        } catch (Exception e) {
+            LOGGER.error("Failed to start image preview", e);
+            previewActive = false;
+        }
+    }
+
+    public static boolean isPreviewActive() {
+        return previewActive;
+    }
+
+    public static ResourceLocation getPreviewTexture() {
+        return pendingTexture;
+    }
+
+    /** Computes where the canvas would land right now, from the player's crosshair. */
+    public static CanvasTransform computeTargetTransform(LocalPlayer player) {
+        double width = widthBlocks;
+        double height = width * aspect;
+
+        Vec3 eye = player.getEyePosition(1.0f);
+        Vec3 look = player.getLookAngle();
+        Vec3 end = eye.add(look.scale(200.0));
+
+        ClipContext ctx = new ClipContext(eye, end, ClipContext.Block.OUTLINE, ClipContext.Fluid.NONE, player);
+        BlockHitResult hit = player.level().clip(ctx);
+
+        Direction facing;
+        Vec3 center;
+
+        if (hit.getType() == HitResult.Type.BLOCK) {
+            Direction face = hit.getDirection();
+            facing = (forcedFacingIndex >= 0)
+                    ? HORIZONTALS[forcedFacingIndex]
+                    : (face.getAxis().isHorizontal() ? face : nearestHorizontalTowardPlayer(look));
+            center = hit.getLocation();
+        } else {
+            facing = (forcedFacingIndex >= 0)
+                    ? HORIZONTALS[forcedFacingIndex]
+                    : nearestHorizontalTowardPlayer(look);
+            center = eye.add(look.scale(Math.max(width, 4.0)));
+        }
+
+        Vec3 normal = Vec3.atLowerCornerOf(facing.getNormal());
+
+        // Snap so the image's edges align to block boundaries (item-frame style).
+        // Quantizes the two in-plane axes (vertical + the horizontal perpendicular to the
+        // facing normal); the depth axis is left on the wall surface.
+        if (snapEnabled) {
+            double x = center.x, y = snapCenter(center.y, height), z = center.z;
+            if (Math.abs(normal.x) > 0.5) {
+                z = snapCenter(center.z, width); // facing E/W -> in-plane horizontal is Z
+            } else {
+                x = snapCenter(center.x, width); // facing N/S -> in-plane horizontal is X
+            }
+            center = new Vec3(x, y, z);
+        }
+
+        // Push the quad slightly off the surface, along the facing normal (toward the viewer).
+        center = center.add(normal.scale(WALL_OFFSET));
+
+        return new CanvasTransform(center, facing, width, height);
+    }
+
+    /** Snaps a center coordinate so the rectangle's lower edge (center - length/2) lands on an integer. */
+    private static double snapCenter(double c, double length) {
+        return Math.round(c - length / 2.0) + length / 2.0;
+    }
+
+    /** The image faces the player: normal points back toward the eye (opposite the look dir). */
+    private static Direction nearestHorizontalTowardPlayer(Vec3 look) {
+        double dx = -look.x;
+        double dz = -look.z;
+        if (Math.abs(dx) > Math.abs(dz)) {
+            return dx > 0 ? Direction.EAST : Direction.WEST;
+        }
+        return dz > 0 ? Direction.SOUTH : Direction.NORTH;
+    }
+
+    public static void rotateFacing() {
+        forcedFacingIndex = (forcedFacingIndex < 0) ? 0 : (forcedFacingIndex + 1) % 4;
+    }
+
+    public static void grow() {
+        widthBlocks = Math.min(MAX_WIDTH_BLOCKS, widthBlocks + 1);
+    }
+
+    public static void shrink() {
+        widthBlocks = Math.max(MIN_WIDTH_BLOCKS, widthBlocks - 1);
+    }
+
+    public static int getWidthBlocks() {
+        return widthBlocks;
+    }
+
+    public static void toggleSnap() {
+        snapEnabled = !snapEnabled;
+    }
+
+    public static boolean isSnapEnabled() {
+        return snapEnabled;
+    }
+
+    /** Confirms placement at the current target, persists it, and exits preview. */
+    public static void confirmPlacement() {
+        if (!previewActive) return;
+        Minecraft mc = Minecraft.getInstance();
+        LocalPlayer player = mc.player;
+        if (player == null || mc.level == null) return;
+
+        CanvasTransform t = computeTargetTransform(player);
+        String dim = mc.level.dimension().location().toString();
+
+        ImageCanvas canvas = new ImageCanvas(pendingId, dim, t.center(), t.facing(),
+                t.width(), t.height(), pendingTexture);
+        placed.add(canvas);
+        saveCanvas(canvas, pendingBytes);
+
+        LOGGER.info("Placed image canvas {} at {} facing {} ({}x{} blocks)",
+                pendingId, t.center(), t.facing(), t.width(), t.height());
+
+        // Exit preview but keep the texture (now owned by the placed canvas).
+        previewActive = false;
+        pendingBytes = null;
+        pendingId = null;
+        pendingTexture = null;
+    }
+
+    /** Cancels the preview and releases the pending texture. */
+    public static void cancelPreview() {
+        if (!previewActive) return;
+        if (pendingTexture != null) {
+            Minecraft.getInstance().getTextureManager().release(pendingTexture);
+        }
+        previewActive = false;
+        pendingBytes = null;
+        pendingId = null;
+        pendingTexture = null;
+        LOGGER.info("Cancelled image preview");
+    }
+
+    public static List<ImageCanvas> getPlacedCanvases() {
+        return placed;
+    }
+
+    // ==================== REMOVAL ====================
+
+    /**
+     * Ray-casts the player's look against placed canvases and removes the nearest one hit.
+     * @return true if a canvas was removed (caller can cancel the block-break)
+     */
+    public static boolean removeLookedAt(Player player) {
+        Vec3 eye = player.getEyePosition(1.0f);
+        Vec3 dir = player.getLookAngle();
+        ImageCanvas hit = pickCanvas(eye, dir, 16.0);
+        if (hit == null) return false;
+        removeCanvas(hit);
+        LOGGER.info("Removed image canvas {}", hit.id);
+        return true;
+    }
+
+    /** Returns the nearest canvas whose rectangle the ray (eye + t*dir) intersects, or null. */
+    private static ImageCanvas pickCanvas(Vec3 eye, Vec3 dir, double maxDist) {
+        ImageCanvas best = null;
+        double bestT = maxDist;
+        for (ImageCanvas c : placed) {
+            Vec3 n = Vec3.atLowerCornerOf(c.facing.getNormal());
+            double denom = dir.dot(n);
+            if (Math.abs(denom) < 1e-6) continue;
+            double t = c.center.subtract(eye).dot(n) / denom;
+            if (t < 0 || t > bestT) continue;
+
+            Vec3 p = eye.add(dir.scale(t));
+            Vec3 right = new Vec3(0, 1, 0).cross(n).normalize();
+            Vec3 d = p.subtract(c.center);
+            double a = d.dot(right);
+            double b = d.y; // up component
+            if (Math.abs(a) <= c.width / 2.0 && Math.abs(b) <= c.height / 2.0) {
+                best = c;
+                bestT = t;
+            }
+        }
+        return best;
+    }
+
+    private static void removeCanvas(ImageCanvas c) {
+        Minecraft.getInstance().getTextureManager().release(c.texture);
+        placed.remove(c);
+        try {
+            Files.deleteIfExists(canvasDir().resolve(c.id + ".png"));
+            List<CanvasRecord> records = readManifest();
+            records.removeIf(r -> c.id.equals(r.id));
+            Files.writeString(manifestPath(), GSON.toJson(records));
+        } catch (Exception e) {
+            LOGGER.error("Failed to delete persisted canvas {}", c.id, e);
+        }
+    }
+
+    /** Removes every canvas in the current dimension. Returns how many were removed. */
+    public static int clearCurrentDimension() {
+        int count = placed.size();
+        // Copy to avoid concurrent modification while removeCanvas mutates `placed`.
+        for (ImageCanvas c : new ArrayList<>(placed)) {
+            removeCanvas(c);
+        }
+        return count;
+    }
+
+    // ==================== PERSISTENCE ====================
+
+    private static Path canvasDir() {
+        return Minecraft.getInstance().gameDirectory.toPath()
+                .resolve("config").resolve("falcraft").resolve("canvases");
+    }
+
+    private static Path manifestPath() {
+        return canvasDir().resolve("canvases.json");
+    }
+
+    private static void saveCanvas(ImageCanvas c, byte[] pngBytes) {
+        try {
+            Path dir = canvasDir();
+            Files.createDirectories(dir);
+            Files.write(dir.resolve(c.id + ".png"), pngBytes);
+
+            List<CanvasRecord> records = readManifest();
+            CanvasRecord r = new CanvasRecord();
+            r.id = c.id;
+            r.dim = c.dim;
+            r.facing = c.facing.getName();
+            r.x = c.center.x;
+            r.y = c.center.y;
+            r.z = c.center.z;
+            r.width = c.width;
+            r.height = c.height;
+            records.add(r);
+
+            Files.writeString(manifestPath(), GSON.toJson(records));
+        } catch (Exception e) {
+            LOGGER.error("Failed to persist image canvas {}", c.id, e);
+        }
+    }
+
+    private static List<CanvasRecord> readManifest() {
+        try {
+            Path mf = manifestPath();
+            if (!Files.exists(mf)) return new ArrayList<>();
+            String json = Files.readString(mf);
+            List<CanvasRecord> list = GSON.fromJson(json, new TypeToken<List<CanvasRecord>>() {}.getType());
+            return list != null ? list : new ArrayList<>();
+        } catch (Exception e) {
+            LOGGER.error("Failed to read canvas manifest", e);
+            return new ArrayList<>();
+        }
+    }
+
+    /**
+     * Loads/unloads persisted canvases as the player changes worlds.
+     * Called every client tick (cheap guard).
+     */
+    public static void tickLoad(Minecraft mc) {
+        if (mc.level == null) {
+            if (loadedDim != null) {
+                releaseAll();
+                loadedDim = null;
+            }
+            return;
+        }
+        String dim = mc.level.dimension().location().toString();
+        if (dim.equals(loadedDim)) return;
+
+        releaseAll();
+        loadForDimension(dim);
+        loadedDim = dim;
+    }
+
+    private static void releaseAll() {
+        var tm = Minecraft.getInstance().getTextureManager();
+        for (ImageCanvas c : placed) {
+            tm.release(c.texture);
+        }
+        placed.clear();
+    }
+
+    private static void loadForDimension(String dim) {
+        List<CanvasRecord> records = readManifest();
+        int loaded = 0;
+        for (CanvasRecord r : records) {
+            if (!dim.equals(r.dim)) continue;
+            try {
+                Path png = canvasDir().resolve(r.id + ".png");
+                if (!Files.exists(png)) continue;
+
+                NativeImage img = NativeImage.read(new ByteArrayInputStream(Files.readAllBytes(png)));
+                ResourceLocation loc = ResourceLocation.fromNamespaceAndPath("falcraft", "canvas/" + r.id);
+                Minecraft.getInstance().getTextureManager().register(loc, new DynamicTexture(img));
+
+                Direction facing = Direction.byName(r.facing);
+                if (facing == null) facing = Direction.NORTH;
+
+                placed.add(new ImageCanvas(r.id, r.dim, new Vec3(r.x, r.y, r.z), facing,
+                        r.width, r.height, loc));
+                loaded++;
+            } catch (Exception e) {
+                LOGGER.error("Failed to load persisted canvas {}", r.id, e);
+            }
+        }
+        if (loaded > 0) {
+            LOGGER.info("Loaded {} image canvas(es) for dimension {}", loaded, dim);
+        }
+    }
+}


### PR DESCRIPTION
Adds /fal image <prompt> (Nano Banana Pro) and /fal image fast <prompt> (Z-Image Turbo). The generated PNG is rendered at full resolution as a textured quad hung in the world, not block pixels.

Placement & controls:
- live preview follows the crosshair onto walls; right-click to place
- block-grid snapping by default (edges align to blocks, tiles cleanly), F toggles free-hand; H/N resize; G rotates facing
- left-click a placed canvas to remove it (AttackBlockCallback cancels the block-break behind it, so no holes in the wall)
- /fal image cancel (abort preview), /fal image clear (remove all in dimension)
- per-dimension disk persistence (PNG + JSON manifest), reloaded on world change

Implementation:
- FalAPI.generatePictureNanoBanana / generatePictureZImage (raw prompt, no 3D augmentation) + shared pollImageResult helper
- ImageCanvasManager: DynamicTexture registration, raycast placement/removal, grid snapping, persistence
- ImageCanvasRenderer: textured quad + frame via WorldRenderEvents
- ImageCommand + FalcraftClient wiring

Client-side / single-player oriented, consistent with block placement.